### PR TITLE
feat: voice input with local VAD + STT pipeline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,11 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.63",
         "@anthropic-ai/sdk": "^0.74.0",
+        "@huggingface/transformers": "^3.7.1",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@opencode-ai/sdk": "^1.2.20",
         "node-sqlite3-wasm": "^0.8.53",
+        "onnxruntime-node": "1.21.0",
         "prism-react-renderer": "^2.4.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -39,9 +41,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.63",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.63.tgz",
-      "integrity": "sha512-ZNiaQb/v6xkbrGt3dtq5J0DGY+AaOhoehUyposa3msvlAlkTHWNGR+NhbCcTE0ML1U91xhPqMAAwZIUqrlkKyQ==",
+      "version": "0.2.71",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.71.tgz",
+      "integrity": "sha512-pIsQJnM7Y+cJHL7aFY6SCCW3FIni218gVEpPqG8XGowfYxboFNBbNssWiUNRwthT8bp9jypcX7q5kx0Xsw14xg==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
@@ -146,9 +148,9 @@
       }
     },
     "node_modules/@azure/core-rest-pipeline": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.22.2.tgz",
-      "integrity": "sha512-MzHym+wOi8CLUlKCQu12de0nwcq9k9Kuv43j4Wa++CsCpJwps2eeBQwD2Bu8snkxTtDKDx4GwjuR9E8yC8LNrg==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.23.0.tgz",
+      "integrity": "sha512-Evs1INHo+jUjwHi1T6SG6Ua/LHOQBCLuKEEE6efIpt4ZOoNonaT1kP32GoOcdNDbfqsD2445CPri3MubBy5DEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -157,7 +159,7 @@
         "@azure/core-tracing": "^1.3.0",
         "@azure/core-util": "^1.13.0",
         "@azure/logger": "^1.3.0",
-        "@typespec/ts-http-runtime": "^0.3.0",
+        "@typespec/ts-http-runtime": "^0.3.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -230,22 +232,22 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.28.2.tgz",
-      "integrity": "sha512-6vYUMvs6kJxJgxaCmHn/F8VxjLHNh7i9wzfwPGf8kyBJ8Gg2yvBXx175Uev8LdrD1F5C4o7qHa2CC4IrhGE1XQ==",
+      "version": "4.29.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.29.0.tgz",
+      "integrity": "sha512-/f3eHkSNUTl6DLQHm+bKecjBKcRQxbd/XLx8lvSYp8Nl/HRyPuIPOijt9Dt0sH50/SxOwQ62RnFCmFlGK+bR/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "15.14.2"
+        "@azure/msal-common": "15.15.0"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "15.14.2",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.14.2.tgz",
-      "integrity": "sha512-n8RBJEUmd5QotoqbZfd+eGBkzuFI1KX6jw2b3WcpSyGjwmzoeI/Jb99opIBPHpb8y312NB+B6+FGi2ZVSR8yfA==",
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.15.0.tgz",
+      "integrity": "sha512-/n+bN0AKlVa+AOcETkJSKj38+bvFs78BaP4rNtv3MJCmPH0YrHiskMRe74OhyZ5DZjGISlFyxqvf9/4QVEi2tw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -253,13 +255,13 @@
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "3.8.7",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.8.7.tgz",
-      "integrity": "sha512-a+Xnrae+uwLnlw68bplS1X4kuJ9F/7K6afuMFyRkNIskhjgDezl5Fhrx+1pmAlDmC0VaaAxjRQMp1OmcqVwkIg==",
+      "version": "3.8.8",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.8.8.tgz",
+      "integrity": "sha512-+f1VrJH1iI517t4zgmuhqORja0bL6LDQXfBqkjuMmfTYXTQQnh1EvwwxO3UbKLT05N0obF72SRHFrC1RBDv5Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "15.14.2",
+        "@azure/msal-common": "15.15.0",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
@@ -299,6 +301,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
+      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -755,6 +767,36 @@
         "hono": "^4"
       }
     },
+    "node_modules/@huggingface/jinja": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.5.tgz",
+      "integrity": "sha512-xRlzazC+QZwr6z4ixEqYHo9fgwhTZ3xNSdljlKfUFGZSdlvt166DljRELFUfFytlYOYvo3vTisA/AFOuOAzFQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@huggingface/transformers": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-3.8.1.tgz",
+      "integrity": "sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@huggingface/jinja": "^0.5.3",
+        "onnxruntime-node": "1.21.0",
+        "onnxruntime-web": "1.22.0-dev.20250409-89f8206ba4",
+        "sharp": "^0.34.1"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@img/sharp-darwin-arm64": {
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
@@ -863,6 +905,54 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@img/sharp-libvips-linux-x64": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
@@ -955,6 +1045,72 @@
         "@img/sharp-libvips-linux-arm64": "1.2.4"
       }
     },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
     "node_modules/@img/sharp-linux-x64": {
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
@@ -1021,12 +1177,50 @@
         "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
       }
     },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@img/sharp-win32-arm64": {
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
       "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
       "cpu": [
         "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
       ],
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
@@ -1067,6 +1261,18 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -1155,15 +1361,79 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.2.20",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.2.20.tgz",
-      "integrity": "sha512-U5ROpG21D8jg9rkc1IgKAk1g5dn6X/rkOBfveupd0peSDO9n6VM9aikYccVLaMObxVqdjtG08IeQOFTPVS8ySQ==",
+      "version": "1.2.21",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.2.21.tgz",
+      "integrity": "sha512-7XF7QlXDP5iAbGcAsxsrmKlIjRtSzKgbwuDHPPuZbILkhGOfCo05XwPidAZrVWucZ/re44oc/psw2zDECaZOpQ==",
       "license": "MIT"
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
-      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
       "cpu": [
         "arm"
       ],
@@ -1175,9 +1445,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
-      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
       "cpu": [
         "arm64"
       ],
@@ -1189,9 +1459,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
-      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
       "cpu": [
         "arm64"
       ],
@@ -1203,9 +1473,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
-      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
       "cpu": [
         "x64"
       ],
@@ -1217,9 +1487,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
-      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
       "cpu": [
         "arm64"
       ],
@@ -1231,9 +1501,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
-      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
       "cpu": [
         "x64"
       ],
@@ -1245,9 +1515,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
-      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
       "cpu": [
         "arm"
       ],
@@ -1259,9 +1529,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
-      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
       "cpu": [
         "arm"
       ],
@@ -1273,9 +1543,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
-      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
       "cpu": [
         "arm64"
       ],
@@ -1287,9 +1557,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
-      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
       "cpu": [
         "arm64"
       ],
@@ -1301,9 +1571,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
-      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
       "cpu": [
         "loong64"
       ],
@@ -1315,9 +1585,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
-      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
       "cpu": [
         "loong64"
       ],
@@ -1329,9 +1599,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
-      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
       "cpu": [
         "ppc64"
       ],
@@ -1343,9 +1613,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
-      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
       "cpu": [
         "ppc64"
       ],
@@ -1357,9 +1627,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
-      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
       "cpu": [
         "riscv64"
       ],
@@ -1371,9 +1641,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
-      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
       "cpu": [
         "riscv64"
       ],
@@ -1385,9 +1655,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
-      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
       "cpu": [
         "s390x"
       ],
@@ -1399,9 +1669,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
-      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
       "cpu": [
         "x64"
       ],
@@ -1413,9 +1683,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
-      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
       "cpu": [
         "x64"
       ],
@@ -1427,9 +1697,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
-      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
       "cpu": [
         "x64"
       ],
@@ -1441,9 +1711,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
-      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
       "cpu": [
         "arm64"
       ],
@@ -1455,9 +1725,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
-      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
       "cpu": [
         "arm64"
       ],
@@ -1469,9 +1739,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
-      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
       "cpu": [
         "ia32"
       ],
@@ -1483,9 +1753,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
-      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
       "cpu": [
         "x64"
       ],
@@ -1497,9 +1767,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
-      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
       "cpu": [
         "x64"
       ],
@@ -1855,10 +2125,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.32",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.32.tgz",
-      "integrity": "sha512-Ez8QE4DMfhjjTsES9K2dwfV258qBui7qxUsoaixZDiTzbde4U12e1pXGNu/ECsUIOi5/zoCxAQxIhQnaUQ2VvA==",
-      "dev": true,
+      "version": "20.19.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
+      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1872,15 +2141,15 @@
       "license": "MIT"
     },
     "node_modules/@types/prismjs": {
-      "version": "1.26.5",
-      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.5.tgz",
-      "integrity": "sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==",
+      "version": "1.26.6",
+      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.6.tgz",
+      "integrity": "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==",
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.2.13",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.13.tgz",
-      "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1927,9 +2196,9 @@
       }
     },
     "node_modules/@typespec/ts-http-runtime": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.3.tgz",
-      "integrity": "sha512-91fp6CAAJSRtH5ja95T1FHSKa8aPW9/Zw6cta81jlZTUw/+Vq8jM/AfF/14h2b71wwR84JUTW/3Y8QPhDAawFA==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.4.tgz",
+      "integrity": "sha512-CI0NhTrz4EBaa0U+HaaUZrJhPoso8sG7ZFya8uQoBA57fjzrjRSv87ekCjLZOFExN+gXE/z0xuN2QfH4H2HrLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2274,9 +2543,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -2488,12 +2757,35 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
     },
     "node_modules/boundary": {
       "version": "2.0.0",
@@ -2745,12 +3037,13 @@
       }
     },
     "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/clsx": {
       "version": "2.1.1",
@@ -3026,6 +3319,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/define-lazy-prop": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
@@ -3037,6 +3347,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/delayed-stream": {
@@ -3071,12 +3398,16 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "license": "MIT"
     },
     "node_modules/devlop": {
       "version": "1.1.0",
@@ -3227,19 +3558,6 @@
         "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
       }
     },
-    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -3330,6 +3648,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
@@ -3376,12 +3700,12 @@
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3584,24 +3908,6 @@
         "pend": "~1.2.0"
       }
     },
-    "node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -3635,6 +3941,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -3720,9 +4032,9 @@
       "optional": true
     },
     "node_modules/fs-extra": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
-      "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3865,9 +4177,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3878,9 +4190,9 @@
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -3891,6 +4203,39 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/globby": {
@@ -3933,6 +4278,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
+      "license": "ISC"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3941,6 +4292,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -4137,19 +4500,16 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ieee754": {
@@ -4485,6 +4845,12 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -4660,6 +5026,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/longest-streak": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
@@ -4721,6 +5093,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4746,10 +5130,22 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mdast-util-from-markdown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
-      "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -5615,19 +6011,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -5681,9 +6064,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5708,10 +6091,21 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/mkdirp-classic": {
@@ -5808,9 +6202,9 @@
       }
     },
     "node_modules/node-sqlite3-wasm": {
-      "version": "0.8.53",
-      "resolved": "https://registry.npmjs.org/node-sqlite3-wasm/-/node-sqlite3-wasm-0.8.53.tgz",
-      "integrity": "sha512-HPuGOPj3L+h3WSf0XikIXTDpsRxlVmzBC3RMgqi3yDg9CEbm/4Hw3rrDodeITqITjm07X4atWLlDMMI8KERMiQ==",
+      "version": "0.8.54",
+      "resolved": "https://registry.npmjs.org/node-sqlite3-wasm/-/node-sqlite3-wasm-0.8.54.tgz",
+      "integrity": "sha512-kGveOnfghdKZbQdDitloHVGBZ1LloRHnLSsjWjd+hZYnHdnk0jA0iN6DpvdHHSwlgeiZX0mNJ7BQfbK9HPtBdw==",
       "license": "MIT"
     },
     "node_modules/normalize-package-data": {
@@ -5882,6 +6276,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -5913,6 +6316,49 @@
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/onnxruntime-common": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.21.0.tgz",
+      "integrity": "sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-node": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.21.0.tgz",
+      "integrity": "sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "global-agent": "^3.0.0",
+        "onnxruntime-common": "1.21.0",
+        "tar": "^7.0.1"
+      }
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.22.0-dev.20250409-89f8206ba4",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.22.0-dev.20250409-89f8206ba4.tgz",
+      "integrity": "sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^25.1.24",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.22.0-dev.20250409-89f8206ba4",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
+      }
+    },
+    "node_modules/onnxruntime-web/node_modules/onnxruntime-common": {
+      "version": "1.22.0-dev.20250409-89f8206ba4",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.22.0-dev.20250409-89f8206ba4.tgz",
+      "integrity": "sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ==",
+      "license": "MIT"
     },
     "node_modules/open": {
       "version": "10.2.0",
@@ -6159,13 +6605,13 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=8.6"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -6180,6 +6626,12 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
+    },
     "node_modules/pluralize": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
@@ -6191,9 +6643,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
       "dev": true,
       "funding": [
         {
@@ -6271,6 +6723,30 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -6285,9 +6761,9 @@
       }
     },
     "node_modules/pump": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -6307,9 +6783,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -6366,6 +6842,22 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -6384,15 +6876,15 @@
       }
     },
     "node_modules/rc-config-loader": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/rc-config-loader/-/rc-config-loader-4.1.3.tgz",
-      "integrity": "sha512-kD7FqML7l800i6pS6pvLyIE2ncbk9Du8Q0gp/4hMPhJU6ZxApkoLcGD8ZeqgiAlfwZ6BlETq6qqe+12DUL207w==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/rc-config-loader/-/rc-config-loader-4.1.4.tgz",
+      "integrity": "sha512-3GiwEzklkbXTDp52UR5nT8iXgYAx1V9ZG/kDZT7p60u2GCv2XTwQq4NzinMoMpNtXhmt3WkhYXcj6HH8HdwCEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.3.4",
-        "js-yaml": "^4.1.0",
-        "json5": "^2.2.2",
+        "debug": "^4.4.3",
+        "js-yaml": "^4.1.1",
+        "json5": "^2.2.3",
         "require-from-string": "^2.0.2"
       }
     },
@@ -6602,10 +7094,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/rollup": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
-      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6619,31 +7128,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.57.1",
-        "@rollup/rollup-android-arm64": "4.57.1",
-        "@rollup/rollup-darwin-arm64": "4.57.1",
-        "@rollup/rollup-darwin-x64": "4.57.1",
-        "@rollup/rollup-freebsd-arm64": "4.57.1",
-        "@rollup/rollup-freebsd-x64": "4.57.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
-        "@rollup/rollup-linux-arm64-musl": "4.57.1",
-        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
-        "@rollup/rollup-linux-loong64-musl": "4.57.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
-        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
-        "@rollup/rollup-linux-x64-gnu": "4.57.1",
-        "@rollup/rollup-linux-x64-musl": "4.57.1",
-        "@rollup/rollup-openbsd-x64": "4.57.1",
-        "@rollup/rollup-openharmony-arm64": "4.57.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
-        "@rollup/rollup-win32-x64-gnu": "4.57.1",
-        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -6728,9 +7237,9 @@
       "license": "MIT"
     },
     "node_modules/sax": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
-      "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
+      "integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -6769,7 +7278,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6777,6 +7285,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "license": "MIT"
     },
     "node_modules/send": {
       "version": "1.2.1",
@@ -6804,6 +7318,33 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/serialize-error/node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/serve-static": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
@@ -6828,6 +7369,50 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -7078,6 +7663,12 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -7165,13 +7756,13 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -7289,6 +7880,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/tar": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.10.tgz",
+      "integrity": "sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -7302,6 +7909,14 @@
         "pump": "^3.0.0",
         "tar-stream": "^2.1.4"
       }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/tar-stream": {
       "version": "2.2.0",
@@ -7319,6 +7934,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/terminal-link": {
@@ -7395,6 +8019,37 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tinyrainbow": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
@@ -7467,7 +8122,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
+      "devOptional": true,
       "license": "0BSD"
     },
     "node_modules/tsx": {
@@ -8028,7 +8683,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -8744,6 +9398,37 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/vitest": {
       "version": "4.0.18",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
@@ -8822,6 +9507,19 @@
         }
       }
     },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
@@ -8834,19 +9532,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/whatwg-mimetype": {

--- a/package.json
+++ b/package.json
@@ -32,9 +32,11 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.63",
     "@anthropic-ai/sdk": "^0.74.0",
+    "@huggingface/transformers": "^3.7.1",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@opencode-ai/sdk": "^1.2.20",
     "node-sqlite3-wasm": "^0.8.53",
+    "onnxruntime-node": "1.21.0",
     "prism-react-renderer": "^2.4.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
@@ -56,9 +58,9 @@
     "ws": "^8.19.0"
   },
   "scripts": {
-    "build:extension": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --sourcemap && cp node_modules/node-sqlite3-wasm/dist/node-sqlite3-wasm.wasm dist/",
+    "build:extension": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --external:onnxruntime-node --external:@huggingface/transformers --format=cjs --platform=node --sourcemap && cp node_modules/node-sqlite3-wasm/dist/node-sqlite3-wasm.wasm dist/",
     "build:webview": "esbuild src/webview/main.tsx --bundle --outfile=dist/webview/main.js --format=esm --platform=browser --sourcemap --jsx=automatic --loader:.svg=text && cp src/webview/index.html dist/webview/ && cp src/webview/theme-defaults.css dist/webview/ && cp src/webview/styles.css dist/webview/",
-    "build:dev-server": "esbuild src/host/dev-server.ts --bundle --outfile=dist/dev-server.js --external:@anthropic-ai/* --external:ws --format=esm --platform=node --sourcemap",
+    "build:dev-server": "esbuild src/host/dev-server.ts --bundle --outfile=dist/dev-server.js --external:@anthropic-ai/* --external:ws --external:onnxruntime-node --external:@huggingface/transformers --format=esm --platform=node --sourcemap",
     "build:internal-mcp": "esbuild src/mcp/servers/internal-main.ts --bundle --outfile=dist/internal-mcp.js --format=cjs --platform=node --sourcemap",
     "build": "npm run build:extension && npm run build:webview && npm run build:dev-server && npm run build:internal-mcp",
     "watch": "npm run build:extension -- --watch",
@@ -96,6 +98,10 @@
       {
         "command": "crispy.blur",
         "title": "Crispy: Focus Editor"
+      },
+      {
+        "command": "crispy.toggleVoiceInput",
+        "title": "Crispy: Toggle Voice Input"
       }
     ],
     "keybindings": [
@@ -115,6 +121,12 @@
         "key": "ctrl+;",
         "mac": "cmd+;",
         "when": "!editorTextFocus && activeWebviewPanelId == 'crispy'"
+      },
+      {
+        "command": "crispy.toggleVoiceInput",
+        "key": "ctrl+shift+space",
+        "mac": "cmd+shift+space",
+        "when": "activeWebviewPanelId == 'crispy'"
       }
     ],
     "menus": {

--- a/src/core/voice/index.ts
+++ b/src/core/voice/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Voice Module — Public API for voice-to-text pipeline
+ *
+ * Re-exports the transcription interface from the voice engine.
+ *
+ * @module voice
+ */
+
+export { transcribeAudio, type TranscribeResult } from './voice-engine.js';

--- a/src/core/voice/stt.ts
+++ b/src/core/voice/stt.ts
@@ -1,0 +1,103 @@
+/**
+ * STT — Moonshine Base Speech-to-Text wrapper
+ *
+ * Transcribes PCM Float32 audio (16kHz mono) to text using
+ * Moonshine Base ONNX via @huggingface/transformers.
+ *
+ * Owns: STT model lifecycle, audio-to-text transcription.
+ *
+ * @module voice/stt
+ */
+
+import {
+  AutoProcessor,
+  MoonshineForConditionalGeneration,
+} from '@huggingface/transformers';
+import { pushRosieLog } from '../rosie/index.js';
+
+// ---------------------------------------------------------------------------
+// Module-level state
+// ---------------------------------------------------------------------------
+
+let processor: Awaited<ReturnType<typeof AutoProcessor.from_pretrained>> | null = null;
+let model: Awaited<ReturnType<typeof MoonshineForConditionalGeneration.from_pretrained>> | null = null;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MODEL_ID = 'onnx-community/moonshine-base-ONNX';
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Load the Moonshine Base processor and model. Safe to call multiple times —
+ * subsequent calls are no-ops.
+ */
+export async function initSTT(): Promise<void> {
+  if (processor && model) return;
+
+  try {
+    pushRosieLog({
+      source: 'voice',
+      level: 'info',
+      summary: 'Loading Moonshine Base STT model...',
+    });
+
+    const [p, m] = await Promise.all([
+      AutoProcessor.from_pretrained(MODEL_ID),
+      MoonshineForConditionalGeneration.from_pretrained(MODEL_ID, {
+        dtype: 'fp32',
+        device: 'cpu',
+      }),
+    ]);
+
+    processor = p;
+    model = m;
+
+    pushRosieLog({
+      source: 'voice',
+      level: 'info',
+      summary: 'Moonshine Base STT model loaded',
+    });
+  } catch (err) {
+    pushRosieLog({
+      source: 'voice',
+      level: 'error',
+      summary: 'Failed to load Moonshine Base STT model',
+      data: err,
+    });
+    throw err;
+  }
+}
+
+/**
+ * Transcribe 16kHz mono PCM Float32 audio to text.
+ *
+ * @returns The transcribed text (empty string for silence / no speech).
+ */
+export async function runSTT(audio: Float32Array): Promise<string> {
+  if (!processor || !model) {
+    throw new Error('STT model not initialised — call initSTT() first');
+  }
+
+  try {
+    const inputs = await processor(audio);
+    const output = await model.generate({ ...inputs, max_new_tokens: 500 });
+    const text: string = processor.batch_decode(output as any, {
+      skip_special_tokens: true,
+    })[0];
+
+    return text.trim();
+  } catch (err) {
+    pushRosieLog({
+      source: 'voice',
+      level: 'error',
+      summary: 'STT transcription failed',
+      data: err,
+    });
+    throw err;
+  }
+}

--- a/src/core/voice/vad.ts
+++ b/src/core/voice/vad.ts
@@ -1,0 +1,195 @@
+/**
+ * VAD — Silero Voice Activity Detection wrapper
+ *
+ * Detects speech segments in PCM Float32 audio (16kHz mono).
+ * Uses onnx-community/silero-vad loaded directly via onnxruntime-node
+ * (the model repo has no config.json so AutoModel.from_pretrained won't work).
+ *
+ * Owns: VAD model lifecycle, speech segment detection.
+ *
+ * @module voice/vad
+ */
+
+import * as ort from 'onnxruntime-node';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { pushRosieLog } from '../rosie/index.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SpeechSegment {
+  /** Start sample index (at 16kHz). */
+  start: number;
+  /** End sample index (at 16kHz). */
+  end: number;
+}
+
+// ---------------------------------------------------------------------------
+// Module-level state
+// ---------------------------------------------------------------------------
+
+let session: ort.InferenceSession | null = null;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const SAMPLE_RATE = 16000;
+const CHUNK_SIZE = 512;
+const SPEECH_THRESHOLD = 0.5;
+const SILENCE_THRESHOLD = 0.3;
+/** Minimum silence duration (in samples at 16kHz) to end a speech segment. */
+const SILENCE_GAP_SAMPLES = 8000; // 500ms at 16kHz
+
+const MODEL_URL = 'https://huggingface.co/onnx-community/silero-vad/resolve/main/onnx/model.onnx';
+
+/** Cache directory for downloaded models. */
+function getCacheDir(): string {
+  return join(homedir(), '.cache', 'crispy', 'silero-vad');
+}
+
+// ---------------------------------------------------------------------------
+// Internal: model download + cache
+// ---------------------------------------------------------------------------
+
+async function downloadModel(): Promise<string> {
+  const cacheDir = getCacheDir();
+  const modelPath = join(cacheDir, 'model.onnx');
+
+  if (existsSync(modelPath)) {
+    pushRosieLog({ source: 'voice', level: 'info', summary: `VAD model cached at ${modelPath}` });
+    return modelPath;
+  }
+
+  pushRosieLog({ source: 'voice', level: 'info', summary: `Downloading Silero VAD model from ${MODEL_URL}...` });
+
+  mkdirSync(cacheDir, { recursive: true });
+
+  const response = await fetch(MODEL_URL);
+  if (!response.ok) {
+    throw new Error(`Failed to download VAD model: HTTP ${response.status} ${response.statusText}`);
+  }
+
+  const buffer = Buffer.from(await response.arrayBuffer());
+  writeFileSync(modelPath, buffer);
+
+  pushRosieLog({ source: 'voice', level: 'info', summary: `VAD model downloaded (${(buffer.byteLength / 1024 / 1024).toFixed(1)} MB)` });
+
+  return modelPath;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Load the Silero VAD ONNX model. Safe to call multiple times — subsequent
+ * calls are no-ops.
+ */
+export async function initVAD(): Promise<void> {
+  if (session) return;
+
+  try {
+    pushRosieLog({ source: 'voice', level: 'info', summary: 'Loading Silero VAD model...' });
+
+    const modelPath = await downloadModel();
+    session = await ort.InferenceSession.create(modelPath);
+
+    pushRosieLog({
+      source: 'voice',
+      level: 'info',
+      summary: `Silero VAD model loaded (inputs: ${session.inputNames.join(', ')}, outputs: ${session.outputNames.join(', ')})`,
+    });
+  } catch (err) {
+    pushRosieLog({ source: 'voice', level: 'error', summary: 'Failed to load Silero VAD model', data: err });
+    throw err;
+  }
+}
+
+/**
+ * Detect speech segments in 16kHz mono PCM Float32 audio.
+ *
+ * Processes audio in 512-sample chunks, applying hysteresis thresholds
+ * (start at >0.5, end after <0.3 sustained for 500ms).
+ *
+ * @returns Array of speech segments as sample-index ranges.
+ */
+export async function runVAD(audio: Float32Array): Promise<SpeechSegment[]> {
+  if (!session) {
+    throw new Error('VAD model not initialised — call initVAD() first');
+  }
+
+  const segments: SpeechSegment[] = [];
+  let inSpeech = false;
+  let segmentStart = 0;
+  let silenceSamples = 0;
+
+  // Silero VAD internal state: combined h+c tensor [2, 1, 128] and sr tensor.
+  let state: ort.Tensor = new ort.Tensor('float32', new Float32Array(256), [2, 1, 128]);
+  const sr = new ort.Tensor('int64', BigInt64Array.from([BigInt(SAMPLE_RATE)]), [1]);
+
+  const totalChunks = Math.floor(audio.length / CHUNK_SIZE);
+
+  pushRosieLog({
+    source: 'voice',
+    level: 'info',
+    summary: `VAD processing ${audio.length} samples (${(audio.length / SAMPLE_RATE).toFixed(1)}s), ${totalChunks} chunks`,
+  });
+
+  for (let i = 0; i < totalChunks; i++) {
+    const offset = i * CHUNK_SIZE;
+    const chunk = audio.subarray(offset, offset + CHUNK_SIZE);
+
+    const inputTensor = new ort.Tensor('float32', chunk, [1, chunk.length]);
+
+    const feeds: Record<string, ort.Tensor> = { input: inputTensor, sr, state };
+    const result = await session.run(feeds);
+
+    const prob = (result.output.data as Float32Array)[0];
+
+    // Update hidden state for next chunk.
+    state = result.stateN;
+
+    if (!inSpeech) {
+      if (prob > SPEECH_THRESHOLD) {
+        inSpeech = true;
+        segmentStart = offset;
+        silenceSamples = 0;
+      }
+    } else {
+      if (prob < SILENCE_THRESHOLD) {
+        silenceSamples += CHUNK_SIZE;
+        if (silenceSamples >= SILENCE_GAP_SAMPLES) {
+          // End segment at the point where silence began.
+          segments.push({
+            start: segmentStart,
+            end: offset - silenceSamples + CHUNK_SIZE,
+          });
+          inSpeech = false;
+          silenceSamples = 0;
+        }
+      } else {
+        silenceSamples = 0;
+      }
+    }
+  }
+
+  // Close any open segment at end of audio.
+  if (inSpeech) {
+    segments.push({
+      start: segmentStart,
+      end: totalChunks * CHUNK_SIZE,
+    });
+  }
+
+  pushRosieLog({
+    source: 'voice',
+    level: 'info',
+    summary: `VAD found ${segments.length} speech segment(s)${segments.length > 0 ? ': ' + segments.map(s => `[${(s.start / SAMPLE_RATE).toFixed(1)}s-${(s.end / SAMPLE_RATE).toFixed(1)}s]`).join(', ') : ''}`,
+  });
+
+  return segments;
+}

--- a/src/core/voice/voice-engine.ts
+++ b/src/core/voice/voice-engine.ts
@@ -1,0 +1,239 @@
+/**
+ * Voice Engine — Lazy-loading Silero VAD + Moonshine Base STT pipeline
+ *
+ * Accepts raw PCM Float32 audio, gates through VAD to detect speech segments,
+ * then transcribes speech segments with Moonshine Base. Models are lazy-downloaded
+ * on first invocation and cached locally by @huggingface/transformers.
+ *
+ * Owns: model lifecycle, VAD->STT pipeline orchestration.
+ * Does not: capture audio, manage UI state, touch ~/.crispy/.
+ *
+ * Platform: requires onnxruntime-node native binaries, which need GLIBC ≥ 2.33.
+ * Snap-packaged VS Code bundles GLIBC 2.31 (core20) and will fail — use the
+ * .deb install instead (`apt install code`). The dev server is unaffected.
+ *
+ * @module voice/voice-engine
+ */
+
+// @huggingface/transformers and voice sub-modules are lazy-loaded to avoid
+// pulling onnxruntime-node native bindings at import time (crashes VS Code's
+// Electron extension host). See ensureModels().
+import { pushRosieLog } from '../rosie/index.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface TranscribeResult {
+  /** Transcribed text (empty string when no speech detected). */
+  text: string;
+  /** Number of speech segments detected by VAD. */
+  segments: number;
+  /** Total processing time in milliseconds. */
+  durationMs: number;
+}
+
+// ---------------------------------------------------------------------------
+// Module-level state
+// ---------------------------------------------------------------------------
+
+/** Cached readiness indicator — true once both models are loaded. */
+let pipeline: { ready: true } | null = null;
+
+/** Deduplication guard so concurrent callers share a single load. */
+let loading: Promise<void> | null = null;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const TARGET_SAMPLE_RATE = 16000;
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+/** Cached lazy-imported sub-modules. */
+let voiceModules: { initVAD: typeof import('./vad.js').initVAD; runVAD: typeof import('./vad.js').runVAD; initSTT: typeof import('./stt.js').initSTT; runSTT: typeof import('./stt.js').runSTT } | null = null;
+
+/**
+ * Lazy-load both VAD and STT models. Concurrent calls coalesce into one
+ * promise so models are only downloaded once.
+ *
+ * Also lazy-imports voice sub-modules and configures @huggingface/transformers
+ * on first call — this avoids loading onnxruntime-node native bindings at
+ * extension activation time.
+ */
+async function ensureModels(): Promise<void> {
+  if (pipeline) return;
+
+  if (!loading) {
+    loading = (async () => {
+      try {
+        pushRosieLog({
+          source: 'voice',
+          level: 'info',
+          summary: 'Initialising voice pipeline (VAD + STT)...',
+        });
+
+        // Configure @huggingface/transformers WASM proxy (safe for Node).
+        const { env } = await import('@huggingface/transformers');
+        if (env.backends.onnx.wasm) {
+          env.backends.onnx.wasm.proxy = false;
+        }
+
+        // Lazy-import sub-modules (pulls onnxruntime-node).
+        const [vadMod, sttMod] = await Promise.all([
+          import('./vad.js'),
+          import('./stt.js'),
+        ]);
+        voiceModules = {
+          initVAD: vadMod.initVAD,
+          runVAD: vadMod.runVAD,
+          initSTT: sttMod.initSTT,
+          runSTT: sttMod.runSTT,
+        };
+
+        await Promise.all([voiceModules.initVAD(), voiceModules.initSTT()]);
+
+        pipeline = { ready: true };
+
+        pushRosieLog({
+          source: 'voice',
+          level: 'info',
+          summary: 'Voice pipeline ready',
+        });
+      } catch (err) {
+        // Reset so a subsequent call can retry.
+        loading = null;
+
+        const msg = err instanceof Error ? err.message : String(err);
+        const isGlibc = msg.includes('GLIBC');
+        pushRosieLog({
+          source: 'voice',
+          level: 'error',
+          summary: isGlibc
+            ? 'Voice requires GLIBC ≥ 2.33. Snap-packaged VS Code ships GLIBC 2.31 — install VS Code via .deb instead (apt install code).'
+            : 'Voice pipeline initialisation failed',
+          data: err,
+        });
+        throw err;
+      }
+    })();
+  }
+
+  await loading;
+}
+
+/**
+ * Resample audio from `srcRate` to `TARGET_SAMPLE_RATE` using simple linear
+ * interpolation. Returns the input unchanged if rates already match.
+ */
+function resampleTo16kHz(
+  audio: Float32Array,
+  srcRate: number,
+): Float32Array {
+  if (srcRate === TARGET_SAMPLE_RATE) return audio;
+
+  const ratio = srcRate / TARGET_SAMPLE_RATE;
+  const outLength = Math.round(audio.length / ratio);
+  const out = new Float32Array(outLength);
+
+  for (let i = 0; i < outLength; i++) {
+    const srcIndex = i * ratio;
+    const lo = Math.floor(srcIndex);
+    const hi = Math.min(lo + 1, audio.length - 1);
+    const frac = srcIndex - lo;
+    out[i] = audio[lo] * (1 - frac) + audio[hi] * frac;
+  }
+
+  return out;
+}
+
+/**
+ * Concatenate multiple Float32Arrays into a single contiguous buffer.
+ */
+function concatFloat32(arrays: Float32Array[]): Float32Array {
+  let totalLength = 0;
+  for (const arr of arrays) totalLength += arr.length;
+
+  const result = new Float32Array(totalLength);
+  let offset = 0;
+  for (const arr of arrays) {
+    result.set(arr, offset);
+    offset += arr.length;
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Full voice-to-text pipeline: resample -> VAD -> STT.
+ *
+ * Models are lazy-downloaded on first call and cached by
+ * `@huggingface/transformers` in the default HF cache directory.
+ *
+ * @param pcmFloat32  Raw PCM audio as Float32Array (values in -1..1).
+ * @param sampleRate  Sample rate of the input audio.
+ * @returns Transcription result with text, segment count, and timing.
+ */
+export async function transcribeAudio(
+  pcmFloat32: Float32Array,
+  sampleRate: number,
+): Promise<TranscribeResult> {
+  const t0 = performance.now();
+
+  try {
+    await ensureModels();
+
+    // 1. Resample to 16kHz if needed.
+    const audio = resampleTo16kHz(pcmFloat32, sampleRate);
+
+    // voiceModules is guaranteed non-null after ensureModels().
+    const { runVAD, runSTT } = voiceModules!;
+
+    // 2. Run VAD to detect speech segments.
+    const speechSegments = await runVAD(audio);
+
+    if (speechSegments.length === 0) {
+      const durationMs = Math.round(performance.now() - t0);
+      pushRosieLog({
+        source: 'voice',
+        level: 'info',
+        summary: `No speech detected (${durationMs}ms)`,
+      });
+      return { text: '', segments: 0, durationMs };
+    }
+
+    // 3. Extract and concatenate speech segments.
+    const speechChunks = speechSegments.map((seg) =>
+      audio.slice(seg.start, seg.end),
+    );
+    const speechAudio = concatFloat32(speechChunks);
+
+    // 4. Transcribe concatenated speech.
+    const text = await runSTT(speechAudio);
+
+    const durationMs = Math.round(performance.now() - t0);
+
+    pushRosieLog({
+      source: 'voice',
+      level: 'info',
+      summary: `Transcribed ${speechSegments.length} segment(s) in ${durationMs}ms: "${text.slice(0, 80)}"`,
+    });
+
+    return { text, segments: speechSegments.length, durationMs };
+  } catch (err) {
+    const durationMs = Math.round(performance.now() - t0);
+    pushRosieLog({
+      source: 'voice',
+      level: 'error',
+      summary: 'transcribeAudio failed',
+      data: err,
+    });
+    throw err;
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@
 
 import * as vscode from 'vscode';
 import { initSettings, startWatchingSettings, stopWatchingSettings } from './core/settings/index.js';
-import { openCrispyPanel, getOrCreatePanelForPrefill } from './host/webview-host.js';
+import { openCrispyPanel, getOrCreatePanelForPrefill, getMostRecentPanel } from './host/webview-host.js';
 import { startRescan, stopRescan } from './core/session-list-manager.js';
 import { runScan } from './core/activity-scanner.js';
 import { findClaudeBinary } from './core/find-claude-binary.js';
@@ -58,6 +58,12 @@ export function activate(context: vscode.ExtensionContext): void {
       setTimeout(() => {
         panel.webview.postMessage({ kind: 'executeInCrispy', content: `Execute the following:\n\n${content}` });
       }, 100);
+    }),
+    vscode.commands.registerCommand('crispy.toggleVoiceInput', () => {
+      const panel = getMostRecentPanel();
+      if (panel) {
+        panel.webview.postMessage({ kind: 'toggleVoiceInput' });
+      }
     }),
   );
 

--- a/src/host/audio-capture.ts
+++ b/src/host/audio-capture.ts
@@ -1,0 +1,439 @@
+/**
+ * Audio Capture — Node.js microphone recording via platform-native tools
+ *
+ * Records audio by spawning OS-native commands that require no user installs:
+ *   - macOS: Swift script using AVAudioRecorder (ships with Xcode CLT)
+ *   - Windows: PowerShell script using winmm.dll MCI commands (built-in)
+ *   - Linux: arecord (ALSA) → parecord (PulseAudio) → pw-record (PipeWire)
+ *
+ * Uses stdin as a signal channel: the recorder process prints RECORDING_STARTED
+ * to stdout when ready, then blocks on readLine(). To stop, we write "\n" to
+ * stdin, the process saves the file and exits.
+ *
+ * Inspired by claude-unbound/damocles recorder architecture.
+ *
+ * Owns: child process lifecycle, temp file management, WAV→Float32 conversion.
+ * Does not: run transcription (caller handles that via voice-engine).
+ *
+ * @module host/audio-capture
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { writeFileSync, promises as fsp } from 'node:fs';
+import { pushRosieLog } from '../core/rosie/index.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface ActiveRecording {
+  process: ChildProcess;
+  tempWavPath: string;
+  tempScriptPath: string | null;
+  startedAt: number;
+}
+
+// ---------------------------------------------------------------------------
+// Module state
+// ---------------------------------------------------------------------------
+
+let activeRecording: ActiveRecording | null = null;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Start capturing microphone audio via platform-native tools.
+ * Resolves when recording has actually started (RECORDING_STARTED signal).
+ *
+ * @throws if recording is already in progress or platform unsupported.
+ */
+export async function startCapture(): Promise<void> {
+  if (activeRecording) {
+    throw new Error('Recording already in progress');
+  }
+
+  const tempWavPath = join(tmpdir(), `crispy-voice-${Date.now()}.wav`);
+
+  pushRosieLog({
+    source: 'voice',
+    level: 'info',
+    summary: `Starting host-side audio capture on ${process.platform}...`,
+  });
+
+  if (process.platform === 'darwin') {
+    await startMacRecording(tempWavPath);
+  } else if (process.platform === 'win32') {
+    await startWindowsRecording(tempWavPath);
+  } else if (process.platform === 'linux') {
+    await startLinuxRecording(tempWavPath);
+  } else {
+    throw new Error(`Voice recording not supported on ${process.platform}`);
+  }
+
+  pushRosieLog({
+    source: 'voice',
+    level: 'info',
+    summary: 'Recording started',
+  });
+}
+
+/**
+ * Stop recording and return captured audio as Float32Array at the recorded sample rate.
+ *
+ * @returns PCM Float32Array (values in -1..1) plus sample rate, or null if
+ *          no recording was active or no audio was captured.
+ */
+export async function stopCapture(): Promise<{ pcmFloat32: Float32Array; sampleRate: number } | null> {
+  if (!activeRecording) {
+    pushRosieLog({
+      source: 'voice',
+      level: 'warn',
+      summary: 'stopCapture called but no recording active',
+    });
+    return null;
+  }
+
+  const { process: proc, tempWavPath, tempScriptPath, startedAt } = activeRecording;
+  activeRecording = null;
+
+  // Signal the recorder to stop by writing to stdin
+  await stopProcess(proc);
+
+  const durationMs = Date.now() - startedAt;
+
+  pushRosieLog({
+    source: 'voice',
+    level: 'info',
+    summary: `Recording stopped after ${durationMs}ms, reading ${tempWavPath}...`,
+  });
+
+  try {
+    const wavBuffer = await fsp.readFile(tempWavPath);
+    const result = wavToFloat32(wavBuffer);
+
+    pushRosieLog({
+      source: 'voice',
+      level: 'info',
+      summary: `WAV decoded: ${result.pcmFloat32.length} samples, ${result.sampleRate}Hz (${(result.pcmFloat32.length / result.sampleRate).toFixed(1)}s)`,
+    });
+
+    return result;
+  } catch (err) {
+    pushRosieLog({
+      source: 'voice',
+      level: 'error',
+      summary: `Failed to read WAV file: ${err instanceof Error ? err.message : err}`,
+    });
+    return null;
+  } finally {
+    // Cleanup temp files
+    fsp.unlink(tempWavPath).catch(() => {});
+    if (tempScriptPath) fsp.unlink(tempScriptPath).catch(() => {});
+  }
+}
+
+/**
+ * Cancel an active recording without returning audio.
+ */
+export function cancelCapture(): void {
+  if (!activeRecording) return;
+
+  const { process: proc, tempWavPath, tempScriptPath } = activeRecording;
+  activeRecording = null;
+
+  proc.kill();
+  fsp.unlink(tempWavPath).catch(() => {});
+  if (tempScriptPath) fsp.unlink(tempScriptPath).catch(() => {});
+
+  pushRosieLog({
+    source: 'voice',
+    level: 'info',
+    summary: 'Recording cancelled',
+  });
+}
+
+/**
+ * Check if a recording is currently active.
+ */
+export function isCapturing(): boolean {
+  return activeRecording !== null;
+}
+
+// ---------------------------------------------------------------------------
+// Platform-specific recorders
+// ---------------------------------------------------------------------------
+
+/**
+ * Spawn a recorder process and wait for the RECORDING_STARTED signal.
+ * The process writes audio to `tempWavPath` and blocks on stdin.
+ */
+function spawnRecorder(
+  command: string,
+  args: string[],
+  tempWavPath: string,
+  tempScriptPath: string | null = null,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(command, args, { stdio: ['pipe', 'pipe', 'pipe'] });
+
+    let resolved = false;
+    let stderrOutput = '';
+
+    proc.stdout?.on('data', (data: Buffer) => {
+      const output = data.toString().trim();
+      pushRosieLog({ source: 'voice', level: 'info', summary: `recorder stdout: ${output}` });
+      if (output.includes('RECORDING_STARTED') && !resolved) {
+        resolved = true;
+        activeRecording = { process: proc, tempWavPath, tempScriptPath, startedAt: Date.now() };
+        resolve();
+      }
+    });
+
+    proc.stderr?.on('data', (data: Buffer) => {
+      stderrOutput += data.toString();
+      pushRosieLog({ source: 'voice', level: 'warn', summary: `recorder stderr: ${data.toString().trim()}` });
+    });
+
+    proc.on('error', (err) => {
+      pushRosieLog({ source: 'voice', level: 'error', summary: `recorder error: ${err.message}` });
+      if (!resolved) {
+        resolved = true;
+        reject(err);
+      }
+    });
+
+    proc.on('close', (code) => {
+      pushRosieLog({ source: 'voice', level: 'info', summary: `recorder exited with code ${code}` });
+      if (!resolved) {
+        resolved = true;
+        reject(new Error(
+          code !== 0
+            ? stderrOutput.trim() || `Recording process exited with code ${code}`
+            : 'Recording process exited without starting',
+        ));
+      }
+    });
+
+    // Timeout: if RECORDING_STARTED doesn't arrive within 15s, give up
+    setTimeout(() => {
+      if (!resolved) {
+        resolved = true;
+        proc.kill();
+        reject(new Error('Recording process startup timed out'));
+      }
+    }, 15_000);
+  });
+}
+
+/** macOS: Swift script using AVAudioRecorder. */
+function startMacRecording(outputPath: string): Promise<void> {
+  const swiftScript = `import AVFoundation
+import Foundation
+
+let outputPath = CommandLine.arguments[1]
+let url = URL(fileURLWithPath: outputPath)
+let semaphore = DispatchSemaphore(value: 0)
+var micGranted = false
+AVCaptureDevice.requestAccess(for: .audio) { granted in
+    micGranted = granted
+    semaphore.signal()
+}
+semaphore.wait()
+guard micGranted else {
+    FileHandle.standardError.write("Microphone access denied. Grant permission in System Settings > Privacy & Security > Microphone.\\n".data(using: .utf8)!)
+    exit(1)
+}
+let settings: [String: Any] = [
+    AVFormatIDKey: Int(kAudioFormatLinearPCM),
+    AVSampleRateKey: 16000.0,
+    AVNumberOfChannelsKey: 1,
+    AVLinearPCMBitDepthKey: 16,
+    AVLinearPCMIsFloatKey: false,
+    AVLinearPCMIsBigEndianKey: false
+]
+do {
+    let recorder = try AVAudioRecorder(url: url, settings: settings)
+    guard recorder.record() else {
+        FileHandle.standardError.write("Failed to start recording\\n".data(using: .utf8)!)
+        exit(1)
+    }
+    print("RECORDING_STARTED")
+    fflush(stdout)
+    _ = readLine()
+    recorder.stop()
+    print("RECORDING_SAVED")
+} catch {
+    FileHandle.standardError.write("Recording error: \\(error.localizedDescription)\\n".data(using: .utf8)!)
+    exit(1)
+}`;
+
+  const scriptPath = join(tmpdir(), `crispy-recorder-${Date.now()}.swift`);
+  writeFileSync(scriptPath, swiftScript);
+
+  return spawnRecorder('swift', [scriptPath, outputPath], outputPath, scriptPath)
+    .catch((err) => {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        throw new Error('Swift not found. Install Xcode Command Line Tools: xcode-select --install');
+      }
+      throw err;
+    });
+}
+
+/** Windows: PowerShell script using winmm.dll MCI commands. */
+function startWindowsRecording(outputPath: string): Promise<void> {
+  const psPath = outputPath.replace(/'/g, "''");
+
+  const script = `$ErrorActionPreference = "Stop"
+Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+public class WinMM {
+    [DllImport("winmm.dll", CharSet=CharSet.Auto)]
+    public static extern int mciSendString(string lpszCommand, StringBuilder lpszReturnString, int cchReturn, IntPtr hwndCallback);
+}
+"@
+$sb = New-Object System.Text.StringBuilder 256
+$outFile = '${psPath}'
+$r = [WinMM]::mciSendString("open new type waveaudio alias crispyrec", $sb, 256, [IntPtr]::Zero)
+if ($r -ne 0) { Write-Error "Failed to open audio device (MCI error $r)"; exit 1 }
+$r = [WinMM]::mciSendString("set crispyrec time format milliseconds", $sb, 256, [IntPtr]::Zero)
+$r = [WinMM]::mciSendString("record crispyrec", $sb, 256, [IntPtr]::Zero)
+if ($r -ne 0) {
+  [WinMM]::mciSendString("close crispyrec", $sb, 256, [IntPtr]::Zero)
+  Write-Error "Failed to start recording (MCI error $r)"
+  exit 1
+}
+Write-Output "RECORDING_STARTED"
+$null = [Console]::In.ReadLine()
+[WinMM]::mciSendString("stop crispyrec", $sb, 256, [IntPtr]::Zero)
+$saveCmd = 'save crispyrec "' + $outFile + '"'
+[WinMM]::mciSendString($saveCmd, $sb, 256, [IntPtr]::Zero)
+[WinMM]::mciSendString("close crispyrec", $sb, 256, [IntPtr]::Zero)
+Write-Output "RECORDING_SAVED"`;
+
+  return spawnRecorder('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', script], outputPath);
+}
+
+/** Linux: tries arecord (ALSA) → parecord (PulseAudio) → pw-record (PipeWire). */
+function startLinuxRecording(outputPath: string): Promise<void> {
+  const script = `OUTPUT="$1"
+if command -v arecord >/dev/null 2>&1; then
+  arecord -f S16_LE -r 16000 -c 1 -t wav -q "$OUTPUT" &
+elif command -v parecord >/dev/null 2>&1; then
+  parecord --format=s16le --rate=16000 --channels=1 --file-format=wav "$OUTPUT" &
+elif command -v pw-record >/dev/null 2>&1; then
+  pw-record --format=s16 --rate=16000 --channels=1 "$OUTPUT" &
+else
+  echo "No audio recorder found. Install one of: alsa-utils (arecord), pulseaudio-utils (parecord), or pipewire (pw-record)." >&2
+  exit 1
+fi
+RECORDER_PID=$!
+sleep 0.2
+if ! kill -0 $RECORDER_PID 2>/dev/null; then
+  echo "Audio recorder failed to start" >&2
+  exit 1
+fi
+trap 'kill -INT $RECORDER_PID 2>/dev/null; wait $RECORDER_PID 2>/dev/null' EXIT
+echo "RECORDING_STARTED"
+read -r
+kill -INT $RECORDER_PID 2>/dev/null
+wait $RECORDER_PID 2>/dev/null
+trap - EXIT
+echo "RECORDING_SAVED"`;
+
+  return spawnRecorder('bash', ['-c', script, '_', outputPath], outputPath);
+}
+
+// ---------------------------------------------------------------------------
+// WAV parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a WAV file buffer into Float32 PCM samples.
+ * Supports 16-bit signed integer PCM (the format all our recorders produce).
+ */
+function wavToFloat32(wav: Buffer): { pcmFloat32: Float32Array; sampleRate: number } {
+  // Validate RIFF header
+  if (wav.toString('ascii', 0, 4) !== 'RIFF' || wav.toString('ascii', 8, 12) !== 'WAVE') {
+    throw new Error('Invalid WAV file');
+  }
+
+  // Find fmt chunk
+  let offset = 12;
+  let sampleRate = 16000;
+  let bitsPerSample = 16;
+  let numChannels = 1;
+
+  while (offset < wav.length - 8) {
+    const chunkId = wav.toString('ascii', offset, offset + 4);
+    const chunkSize = wav.readUInt32LE(offset + 4);
+
+    if (chunkId === 'fmt ') {
+      numChannels = wav.readUInt16LE(offset + 10);
+      sampleRate = wav.readUInt32LE(offset + 12);
+      bitsPerSample = wav.readUInt16LE(offset + 22);
+    }
+
+    if (chunkId === 'data') {
+      const dataStart = offset + 8;
+      const dataEnd = Math.min(dataStart + chunkSize, wav.length);
+      const dataSlice = wav.subarray(dataStart, dataEnd);
+
+      if (bitsPerSample !== 16) {
+        throw new Error(`Unsupported WAV bit depth: ${bitsPerSample} (expected 16)`);
+      }
+
+      // Convert 16-bit signed integer PCM to Float32 (-1..1)
+      // If stereo, take only the first channel
+      const bytesPerSample = 2;
+      const frameSize = bytesPerSample * numChannels;
+      const frameCount = Math.floor(dataSlice.length / frameSize);
+      const pcmFloat32 = new Float32Array(frameCount);
+
+      for (let i = 0; i < frameCount; i++) {
+        pcmFloat32[i] = dataSlice.readInt16LE(i * frameSize) / 32768;
+      }
+
+      return { pcmFloat32, sampleRate };
+    }
+
+    offset += 8 + chunkSize;
+    // Chunks are 2-byte aligned
+    if (chunkSize % 2 !== 0) offset++;
+  }
+
+  throw new Error('WAV file has no data chunk');
+}
+
+// ---------------------------------------------------------------------------
+// Process lifecycle
+// ---------------------------------------------------------------------------
+
+/** Signal the recorder process to stop by writing to stdin, wait for exit. */
+function stopProcess(proc: ChildProcess): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (proc.exitCode !== null) {
+      resolve();
+      return;
+    }
+
+    const timeout = setTimeout(() => {
+      proc.kill();
+      reject(new Error('Stop recording timed out'));
+    }, 10_000);
+
+    proc.on('close', () => {
+      clearTimeout(timeout);
+      resolve();
+    });
+
+    // Signal stop via stdin
+    proc.stdin?.write('\n');
+    proc.stdin?.end();
+  });
+}

--- a/src/host/client-connection.ts
+++ b/src/host/client-connection.ts
@@ -51,12 +51,17 @@ import {
   subscribeRosieLog,
   unsubscribeRosieLog,
   ROSIE_LOG_CHANNEL_ID,
+  pushRosieLog,
 } from "../core/rosie/debug-log.js";
 import type { RosieLogEvent, RosieLogSubscriber } from "../core/rosie/debug-log.js";
 import { getGitFiles, fileExists, readImage, readTextFile } from "../core/file-service.js";
 import { queryActivity, getLineage, getChildSessions, getLineageGraph } from '../core/activity-index.js';
 import { readResponsePreview } from '../core/adapters/claude/jsonl-reader.js';
 import { readCodexResponsePreview } from '../core/adapters/codex/codex-jsonl-reader.js';
+// Voice module is lazy-loaded to avoid pulling onnxruntime-node native bindings
+// at extension activation time (crashes VS Code's Electron host).
+// import { transcribeAudio } from '../core/voice/index.js'; // <-- lazy below
+import { startCapture, stopCapture } from './audio-capture.js';
 
 // ============================================================================
 // Path Containment
@@ -546,6 +551,64 @@ export function createClientConnection(
 
       case "getLineageGraph": {
         return getLineageGraph();
+      }
+
+      case "transcribeAudio": {
+        const audioBase64 = params.audioBase64 as string;
+        const sampleRate = params.sampleRate as number;
+
+        // Decode base64 → Float32Array
+        const binary = Buffer.from(audioBase64, 'base64');
+        pushRosieLog({
+          source: 'voice',
+          level: 'info',
+          summary: `RPC transcribeAudio received: ${binary.byteLength} bytes, sampleRate=${sampleRate}, base64 length=${audioBase64.length}`,
+        });
+        if (binary.byteLength % 4 !== 0) {
+          throw new Error(`Audio buffer length ${binary.byteLength} is not aligned to 4 bytes`);
+        }
+        const pcmFloat32 = new Float32Array(binary.buffer, binary.byteOffset, binary.byteLength / 4);
+        pushRosieLog({
+          source: 'voice',
+          level: 'info',
+          summary: `Decoded ${pcmFloat32.length} samples (${(pcmFloat32.length / sampleRate).toFixed(1)}s), calling transcribeAudio...`,
+        });
+
+        const { transcribeAudio } = await import('../core/voice/index.js');
+        const result = await transcribeAudio(pcmFloat32, sampleRate);
+        pushRosieLog({
+          source: 'voice',
+          level: 'info',
+          summary: `transcribeAudio result: ${result.segments} segments, ${result.durationMs}ms, text="${result.text.slice(0, 80)}"`,
+        });
+        return { text: result.text };
+      }
+
+      case "startVoiceCapture": {
+        await startCapture();
+        return { started: true };
+      }
+
+      case "stopVoiceCapture": {
+        const captured = await stopCapture();
+        if (!captured) {
+          return { text: '' };
+        }
+
+        pushRosieLog({
+          source: 'voice',
+          level: 'info',
+          summary: `Host capture: ${captured.pcmFloat32.length} samples (${(captured.pcmFloat32.length / captured.sampleRate).toFixed(1)}s), running transcription...`,
+        });
+
+        const { transcribeAudio: transcribe } = await import('../core/voice/index.js');
+        const txResult = await transcribe(captured.pcmFloat32, captured.sampleRate);
+        pushRosieLog({
+          source: 'voice',
+          level: 'info',
+          summary: `Host capture transcription: ${txResult.segments} segments, ${txResult.durationMs}ms, text="${txResult.text.slice(0, 80)}"`,
+        });
+        return { text: txResult.text };
       }
 
       default:

--- a/src/host/webview-host.ts
+++ b/src/host/webview-host.ts
@@ -33,7 +33,7 @@ function isAnyPanelActive(): boolean {
 /**
  * Get the most recently created panel (last in insertion order).
  */
-function getMostRecentPanel(): vscode.WebviewPanel | undefined {
+export function getMostRecentPanel(): vscode.WebviewPanel | undefined {
   const all = Array.from(panels.values());
   return all[all.length - 1];
 }
@@ -295,7 +295,7 @@ function getWebviewHtml(
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta
     http-equiv="Content-Security-Policy"
-    content="default-src 'none'; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'unsafe-inline'; img-src ${webview.cspSource} data: blob:; font-src ${webview.cspSource};"
+    content="default-src 'none'; script-src 'nonce-${nonce}'; style-src ${webview.cspSource} 'unsafe-inline'; img-src ${webview.cspSource} data: blob:; font-src ${webview.cspSource}; media-src 'self';"
   >
   <title>Crispy</title>
   <link rel="stylesheet" href="${cssUri}">

--- a/src/webview/components/control-panel/ChatInput.tsx
+++ b/src/webview/components/control-panel/ChatInput.tsx
@@ -1,18 +1,20 @@
 /**
- * Chat Input — auto-resizing textarea with send button
+ * Chat Input — auto-resizing textarea with send button and voice input
  *
  * Textarea auto-grows up to 300px. Ctrl+Enter triggers send.
  * Send button uses hover jiggle animation.
  * Supports @-mention autocomplete for file paths.
+ * Mic button toggles push-to-talk voice recording.
  *
  * @module control-panel/ChatInput
  */
 
 import { useRef, useLayoutEffect, useEffect, useCallback } from 'react';
 import type { AttachedImage } from './types.js';
-import { ForkIcon } from './icons.js';
+import { ForkIcon, MicIcon } from './icons.js';
 import { useMention } from '../../hooks/useMention.js';
 import { MentionDropdown } from './MentionDropdown.js';
+import type { VoiceState } from '../../hooks/useVoiceInput.js';
 
 interface ChatInputProps {
   value: string;
@@ -22,9 +24,13 @@ interface ChatInputProps {
   placeholder?: string;
   forkMode?: boolean;
   onFork?: () => void;
+  /** Voice input state — 'idle' | 'recording' | 'transcribing'. */
+  voiceState?: VoiceState;
+  /** Toggle voice recording on/off. */
+  onVoiceToggle?: () => void;
 }
 
-export function ChatInput({ value, attachedImages, onInput, onSend, placeholder, forkMode, onFork }: ChatInputProps): React.JSX.Element {
+export function ChatInput({ value, attachedImages, onInput, onSend, placeholder, forkMode, onFork, voiceState = 'idle', onVoiceToggle }: ChatInputProps): React.JSX.Element {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const mention = useMention(textareaRef, value, onInput);
 
@@ -33,16 +39,18 @@ export function ChatInput({ value, attachedImages, onInput, onSend, placeholder,
     textareaRef.current?.focus();
   }, []);
 
-  // Focus textarea when host sends focusInput message (e.g. keybinding, panel activation)
+  // Handle host messages: focusInput (keybinding, panel activation), toggleVoiceInput (VS Code keybinding)
   useEffect(() => {
     function onMessage(ev: MessageEvent): void {
       if (ev.data?.kind === 'focusInput') {
         textareaRef.current?.focus();
+      } else if (ev.data?.kind === 'toggleVoiceInput') {
+        onVoiceToggle?.();
       }
     }
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
-  }, []);
+  }, [onVoiceToggle]);
 
   // Auto-resize textarea when value changes
   useLayoutEffect(() => {
@@ -99,6 +107,12 @@ export function ChatInput({ value, attachedImages, onInput, onSend, placeholder,
 
   const isEmpty = !value.trim() && attachedImages.length === 0;
 
+  const micTitle = voiceState === 'recording'
+    ? 'Stop recording (Ctrl+Shift+Space)'
+    : voiceState === 'transcribing'
+      ? 'Transcribing...'
+      : 'Voice input (Ctrl+Shift+Space)';
+
   return (
     <div className="crispy-cp-input-row">
       {mention.active && (mention.results.length > 0 || mention.query.length > 0) && (
@@ -119,6 +133,17 @@ export function ChatInput({ value, attachedImages, onInput, onSend, placeholder,
         onKeyDown={handleKeyDown}
         onSelect={(e) => mention.handleInputChange(e.currentTarget)}
       />
+      {onVoiceToggle && (
+        <button
+          className={`crispy-cp-mic ${voiceState !== 'idle' ? `crispy-cp-mic--${voiceState}` : ''}`}
+          title={micTitle}
+          disabled={voiceState === 'transcribing'}
+          onClick={onVoiceToggle}
+          type="button"
+        >
+          <MicIcon />
+        </button>
+      )}
       <button
         className={`crispy-cp-send ${forkMode ? 'crispy-cp-send--fork' : ''}`}
         title={forkMode ? "Send forked message (Ctrl+Enter)" : "Send message (Ctrl+Enter)"}

--- a/src/webview/components/control-panel/ControlPanel.tsx
+++ b/src/webview/components/control-panel/ControlPanel.tsx
@@ -44,6 +44,7 @@ import { slugToPath } from '../../hooks/useSessionCwd.js';
 import { useContextUsage } from '../../hooks/useContextUsage.js';
 import { useSessionStatus } from '../../hooks/useSessionStatus.js';
 import { useRosieLog } from '../../hooks/useRosieLog.js';
+import { useVoiceInput } from '../../hooks/useVoiceInput.js';
 import { extractFilePathsFromDragEvent, isImageExtension } from '../../utils/drag-drop.js';
 import type { MessageContent, MessageContentBlock, TranscriptEntry } from '../../../core/transcript.js';
 import type { TurnIntent, TurnTarget } from '../../../core/agent-adapter.js';
@@ -162,6 +163,7 @@ export const ControlPanel = forwardRef<HTMLDivElement, ControlPanelProps>(
     const [rosiePanelPinned, setRosiePanelPinned] = useState(false);
     const rosieLogEntries = useRosieLog();
     const transport = useTransport();
+
     const { selectedSessionId, selectedCwd, setSelectedSessionId, sessions, workspaceCwdPath } = useSession();
     const { channelState, setOptimistic: setOptimisticStatus } = useSessionStatus(selectedSessionId);
     const togglesDisabled = channelState === 'streaming' || channelState === 'awaiting_approval';
@@ -183,6 +185,34 @@ export const ControlPanel = forwardRef<HTMLDivElement, ControlPanelProps>(
       setSendError(null);
       if (sendErrorTimerRef.current) { clearTimeout(sendErrorTimerRef.current); sendErrorTimerRef.current = null; }
     }, []);
+
+    // --- Voice input ---
+    // In VS Code mode, delegate recording + transcription to extension host
+    // (Electron denies getUserMedia in webview iframes).
+    const hostCapture = useMemo(() => {
+      if (!transport.startVoiceCapture || !transport.stopVoiceCapture) return undefined;
+      const start = transport.startVoiceCapture.bind(transport);
+      const stop = transport.stopVoiceCapture.bind(transport);
+      return { start, stop };
+    }, [transport]);
+
+    const voice = useVoiceInput({
+      transcribe: useCallback((pcm: Float32Array, sr: number) => transport.transcribeAudio(pcm, sr), [transport]),
+      onTranscript: useCallback((text: string) => {
+        // Append transcribed text to existing input (hybrid input support).
+        // Read current value from DOM since useReducer doesn't support functional updates.
+        const textarea = document.querySelector<HTMLTextAreaElement>('.crispy-cp-input');
+        const current = textarea?.value ?? '';
+        const separator = current && !current.endsWith(' ') ? ' ' : '';
+        dispatch({ type: 'SET_INPUT', value: current + separator + text });
+        textarea?.focus();
+      }, []),
+      onError: useCallback((error: string) => {
+        console.error('[Voice]', error);
+        showSendError(`Voice: ${error}`);
+      }, [showSendError]),
+      hostCapture,
+    });
 
     // --- Compact mode detection via ResizeObserver ---
     // Matches the @container (max-width: 480px) breakpoint in CSS.
@@ -399,11 +429,20 @@ export const ControlPanel = forwardRef<HTMLDivElement, ControlPanelProps>(
           dispatch({ type: 'SET_MODEL', model: next });
           return;
         }
+
+        // Ctrl+Shift+Space / Cmd+Shift+Space: Toggle voice input (dev-server fallback)
+        // Use e.code (physical key) — e.key is unreliable with input methods.
+        if (e.code === 'Space' && (e.ctrlKey || e.metaKey) && e.shiftKey && !e.altKey) {
+          e.preventDefault();
+          console.log('[Voice] keyboard shortcut Ctrl+Shift+Space fired, voice.state:', voice.state);
+          voice.toggle();
+          return;
+        }
       };
 
       document.addEventListener('keydown', handleKeyDown);
       return () => document.removeEventListener('keydown', handleKeyDown);
-    }, [state.bypassEnabled, state.agencyMode, state.model, togglesDisabled, allCyclable]);
+    }, [state.bypassEnabled, state.agencyMode, state.model, togglesDisabled, allCyclable, voice]);
 
     // --- Server → UI: settings sync notifications ---
     // Server-initiated setting changes update the local state. Handles both
@@ -918,6 +957,8 @@ export const ControlPanel = forwardRef<HTMLDivElement, ControlPanelProps>(
               onSend={handleSend}
               forkMode={!!state.forkMode}
               onFork={handleFork}
+              voiceState={voice.state}
+              onVoiceToggle={voice.toggle}
             />
           </>
         )}

--- a/src/webview/components/control-panel/icons.tsx
+++ b/src/webview/components/control-panel/icons.tsx
@@ -94,3 +94,13 @@ export function RewindIcon({ className, ...props }: IconProps): React.JSX.Elemen
 export function ForkIcon({ className, ...props }: IconProps): React.JSX.Element {
   return <span className={className} {...props}>⑂</span>;
 }
+
+/** Microphone icon — voice input. */
+export function MicIcon({ className, ...props }: IconProps): React.JSX.Element {
+  return (
+    <svg className={className} width="16" height="16" viewBox="0 0 16 16" fill="currentColor" {...props}>
+      <path d="M8 1a2 2 0 0 0-2 2v4a2 2 0 1 0 4 0V3a2 2 0 0 0-2-2z" />
+      <path d="M3.5 6.5a.5.5 0 0 1 1 0V7a3.5 3.5 0 1 0 7 0v-.5a.5.5 0 0 1 1 0V7a4.5 4.5 0 0 1-4 4.473V13.5h2a.5.5 0 0 1 0 1h-5a.5.5 0 0 1 0-1h2v-2.027A4.5 4.5 0 0 1 3.5 7V6.5z" />
+    </svg>
+  );
+}

--- a/src/webview/hooks/useVoiceInput.ts
+++ b/src/webview/hooks/useVoiceInput.ts
@@ -1,0 +1,271 @@
+/**
+ * useVoiceInput — Push-to-talk voice capture hook
+ *
+ * Two capture modes:
+ * - **Browser** (dev server): getUserMedia → ScriptProcessorNode → PCM → host transcription
+ * - **Host** (VS Code): delegates recording + transcription entirely to extension host,
+ *   bypassing Electron's getUserMedia restriction in webview iframes.
+ *
+ * Click-to-start, click-to-stop interaction model.
+ *
+ * Owns: MediaStream lifecycle (browser mode), recording state.
+ * Does not: run STT (host does that), modify chat input (caller does that).
+ *
+ * @module hooks/useVoiceInput
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export type VoiceState = 'idle' | 'recording' | 'transcribing';
+
+interface UseVoiceInputOptions {
+  /** RPC call to host: send audio, get text back (browser capture mode) */
+  transcribe: (pcmFloat32: Float32Array, sampleRate: number) => Promise<{ text: string }>;
+  /** Called when transcription completes with non-empty text */
+  onTranscript: (text: string) => void;
+  /** Called on errors (mic denied, transcription failed, etc.) */
+  onError?: (error: string) => void;
+  /**
+   * Host-side audio capture (VS Code mode). When provided, recording + transcription
+   * are fully delegated to the extension host — getUserMedia is not used.
+   */
+  hostCapture?: {
+    start: () => Promise<void>;
+    stop: () => Promise<{ text: string }>;
+  };
+}
+
+interface UseVoiceInputResult {
+  state: VoiceState;
+  toggle: () => void;
+}
+
+/**
+ * Concatenate an array of Float32Arrays into a single contiguous Float32Array.
+ */
+function concatFloat32Arrays(arrays: Float32Array[]): Float32Array {
+  let totalLength = 0;
+  for (const arr of arrays) {
+    totalLength += arr.length;
+  }
+  const result = new Float32Array(totalLength);
+  let offset = 0;
+  for (const arr of arrays) {
+    result.set(arr, offset);
+    offset += arr.length;
+  }
+  return result;
+}
+
+export function useVoiceInput(options: UseVoiceInputOptions): UseVoiceInputResult {
+  const [state, setState] = useState<VoiceState>('idle');
+
+  // Stable ref for options to avoid stale closures in async flows.
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  // ---------- Browser capture refs (unused in host mode) ----------
+  const mediaStreamRef = useRef<MediaStream | null>(null);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const processorRef = useRef<ScriptProcessorNode | null>(null);
+  const sourceRef = useRef<MediaStreamAudioSourceNode | null>(null);
+  const chunksRef = useRef<Float32Array[]>([]);
+
+  /**
+   * Tear down browser audio resources. Safe to call multiple times.
+   * No-op in host capture mode (nothing to clean up client-side).
+   */
+  const teardown = useCallback(() => {
+    if (processorRef.current) {
+      processorRef.current.disconnect();
+      processorRef.current.onaudioprocess = null;
+      processorRef.current = null;
+    }
+    if (sourceRef.current) {
+      sourceRef.current.disconnect();
+      sourceRef.current = null;
+    }
+    if (mediaStreamRef.current) {
+      for (const track of mediaStreamRef.current.getTracks()) {
+        track.stop();
+      }
+      mediaStreamRef.current = null;
+    }
+    if (audioContextRef.current) {
+      audioContextRef.current.close().catch(() => {});
+      audioContextRef.current = null;
+    }
+  }, []);
+
+  // ================================================================
+  // Host capture mode (VS Code)
+  // ================================================================
+
+  const startHostRecording = useCallback(async () => {
+    const hostCapture = optionsRef.current.hostCapture;
+    if (!hostCapture) return;
+
+    console.log('[Voice] startHostRecording: delegating to extension host...');
+    try {
+      await hostCapture.start();
+      setState('recording');
+      console.log('[Voice] host recording started');
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to start host recording';
+      console.error('[Voice] startHostRecording error:', err);
+      optionsRef.current.onError?.(message);
+    }
+  }, []);
+
+  const stopHostAndTranscribe = useCallback(async () => {
+    const hostCapture = optionsRef.current.hostCapture;
+    if (!hostCapture) return;
+
+    console.log('[Voice] stopHostAndTranscribe: stopping host capture...');
+    setState('transcribing');
+
+    try {
+      const { text } = await hostCapture.stop();
+      console.log(`[Voice] host transcription result: "${text.slice(0, 100)}"${text.length > 100 ? '...' : ''}`);
+      if (text.trim().length > 0) {
+        optionsRef.current.onTranscript(text);
+      } else {
+        console.log('[Voice] empty host transcription, no text appended');
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Host transcription failed';
+      console.error('[Voice] host transcription error:', err);
+      optionsRef.current.onError?.(message);
+    } finally {
+      setState('idle');
+    }
+  }, []);
+
+  // ================================================================
+  // Browser capture mode (dev server)
+  // ================================================================
+
+  /**
+   * Start capturing microphone audio at 16 kHz mono via Web Audio API.
+   */
+  const startBrowserRecording = useCallback(async () => {
+    console.log('[Voice] startBrowserRecording: requesting getUserMedia...');
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      console.log('[Voice] getUserMedia granted, tracks:', stream.getAudioTracks().map(t => `${t.label} (${t.readyState})`));
+
+      // Request 16 kHz; the browser may give a different rate — host resamples.
+      const audioContext = new AudioContext({ sampleRate: 16000 });
+      console.log('[Voice] AudioContext created, sampleRate:', audioContext.sampleRate, 'state:', audioContext.state);
+
+      const source = audioContext.createMediaStreamSource(stream);
+
+      // ScriptProcessorNode is deprecated but universally supported.
+      // AudioWorklet requires a separate module file — overkill for this use case.
+      const processor = audioContext.createScriptProcessor(4096, 1, 1);
+      const chunks: Float32Array[] = [];
+
+      processor.onaudioprocess = (e: AudioProcessingEvent) => {
+        const channelData = e.inputBuffer.getChannelData(0);
+        // Copy — the underlying buffer is reused by the audio pipeline.
+        chunks.push(new Float32Array(channelData));
+        if (chunks.length % 50 === 1) {
+          console.log(`[Voice] recording chunk #${chunks.length}, buffer size: ${chunks.length * channelData.length} samples`);
+        }
+      };
+
+      source.connect(processor);
+      processor.connect(audioContext.destination);
+
+      mediaStreamRef.current = stream;
+      audioContextRef.current = audioContext;
+      sourceRef.current = source;
+      processorRef.current = processor;
+      chunksRef.current = chunks;
+
+      setState('recording');
+      console.log('[Voice] browser recording started');
+    } catch (err: unknown) {
+      const message =
+        err instanceof DOMException && err.name === 'NotAllowedError'
+          ? 'Microphone access denied'
+          : err instanceof Error
+            ? err.message
+            : 'Failed to start recording';
+      console.error('[Voice] startBrowserRecording error:', err);
+      optionsRef.current.onError?.(message);
+    }
+  }, []);
+
+  /**
+   * Stop browser recording, concatenate captured audio, send to host for transcription.
+   */
+  const stopBrowserAndTranscribe = useCallback(async () => {
+    const sampleRate = audioContextRef.current?.sampleRate ?? 16000;
+    const chunks = chunksRef.current;
+
+    console.log(`[Voice] stopBrowserAndTranscribe: ${chunks.length} chunks, sampleRate: ${sampleRate}`);
+    teardown();
+
+    if (chunks.length === 0) {
+      console.log('[Voice] no audio chunks captured, returning to idle');
+      setState('idle');
+      return;
+    }
+
+    const pcm = concatFloat32Arrays(chunks);
+    chunksRef.current = [];
+
+    console.log(`[Voice] sending ${pcm.length} samples (${(pcm.length / sampleRate).toFixed(1)}s) to host for transcription...`);
+    setState('transcribing');
+
+    try {
+      const { text } = await optionsRef.current.transcribe(pcm, sampleRate);
+      console.log(`[Voice] transcription result: "${text.slice(0, 100)}"${text.length > 100 ? '...' : ''}`);
+      if (text.trim().length > 0) {
+        optionsRef.current.onTranscript(text);
+      } else {
+        console.log('[Voice] empty transcription, no text appended');
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Transcription failed';
+      console.error('[Voice] transcription error:', err);
+      optionsRef.current.onError?.(message);
+    } finally {
+      setState('idle');
+    }
+  }, [teardown]);
+
+  // ================================================================
+  // Toggle — dispatches to host or browser mode
+  // ================================================================
+
+  const toggle = useCallback(() => {
+    const useHost = !!optionsRef.current.hostCapture;
+    console.log(`[Voice] toggle called, current state: ${state}, mode: ${useHost ? 'host' : 'browser'}`);
+
+    if (state === 'idle') {
+      if (useHost) {
+        startHostRecording();
+      } else {
+        startBrowserRecording();
+      }
+    } else if (state === 'recording') {
+      if (useHost) {
+        stopHostAndTranscribe();
+      } else {
+        stopBrowserAndTranscribe();
+      }
+    }
+    // 'transcribing' — ignore clicks while processing.
+  }, [state, startHostRecording, stopHostAndTranscribe, startBrowserRecording, stopBrowserAndTranscribe]);
+
+  // Cleanup on unmount: stop recording if still active.
+  useEffect(() => {
+    return () => {
+      teardown();
+    };
+  }, [teardown]);
+
+  return { state, toggle };
+}

--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -1690,7 +1690,7 @@ h2 {
   flex: 1 1 0%; /* Grow to fill, shrink allowed, zero basis for flex calc */
   min-width: 0; /* Allow flex shrinking below content size */
   min-height: 32px; /* Never collapse vertically */
-  padding: 6px calc(4em + 18px) 6px 8px; /* Right padding reserves space for overlaid send button */
+  padding: 6px calc(4em + 48px) 6px 8px; /* Right padding reserves space for mic + send buttons */
   background: var(--tint-light);
   color: var(--vscode-input-foreground, #d4d4d4);
   border: 1px solid var(--tint-light);
@@ -1771,6 +1771,68 @@ h2 {
   color: inherit;
   font-weight: 600;
   border-radius: 1px;
+}
+
+/* --- Mic Button (Voice Input) --- */
+
+.crispy-cp-mic {
+  position: absolute;
+  right: calc(4em + 12px);
+  bottom: 7px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  background: transparent;
+  color: var(--vscode-descriptionForeground, #858585);
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  transition: color 0.15s, background 0.15s;
+  appearance: none;
+  -webkit-appearance: none;
+  outline: none;
+  z-index: 1;
+}
+
+.crispy-cp-mic:hover:not(:disabled) {
+  color: var(--vscode-input-foreground, #d4d4d4);
+  background: var(--vscode-list-hoverBackground, #2a2d2e);
+}
+
+.crispy-cp-mic:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* Recording state — pulsing red */
+.crispy-cp-mic--recording {
+  color: #ef4444;
+  animation: crispy-cp-mic-pulse 1s ease-in-out infinite;
+}
+
+.crispy-cp-mic--recording:hover:not(:disabled) {
+  color: #ef4444;
+  background: rgba(239, 68, 68, 0.15);
+}
+
+/* Transcribing state — subtle spin/pulse */
+.crispy-cp-mic--transcribing {
+  color: var(--color-accent);
+  animation: crispy-cp-mic-spin 1s linear infinite;
+}
+
+@keyframes crispy-cp-mic-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+@keyframes crispy-cp-mic-spin {
+  0% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(0.85); opacity: 0.6; }
+  100% { transform: scale(1); opacity: 1; }
 }
 
 /* --- Send Button --- */

--- a/src/webview/transport-vscode.ts
+++ b/src/webview/transport-vscode.ts
@@ -13,6 +13,7 @@ import type { TranscriptEntry } from '../core/transcript.js';
 import type { TurnReceipt } from '../core/agent-adapter.js';
 import type { WireProviderConfig, WireSettingsSnapshot, SettingsPatch } from '../core/settings/types.js';
 import type { VendorModelGroup } from './components/control-panel/types.js';
+import { float32ToBase64 } from './utils/encoding.js';
 
 interface VSCodeAPI {
   postMessage(message: unknown): void;
@@ -66,13 +67,13 @@ export function createVSCodeTransport(api: VSCodeAPI): SessionService {
 
   window.addEventListener('message', onMessage);
 
-  function request<T>(method: string, params?: Record<string, unknown>): Promise<T> {
+  function request<T>(method: string, params?: Record<string, unknown>, timeoutMs = REQUEST_TIMEOUT_MS): Promise<T> {
     return new Promise<T>((resolve, reject) => {
       const id = nextId();
       const timer = setTimeout(() => {
         pending.delete(id);
-        reject(new Error(`Request "${method}" timed out after ${REQUEST_TIMEOUT_MS}ms`));
-      }, REQUEST_TIMEOUT_MS);
+        reject(new Error(`Request "${method}" timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
 
       pending.set(id, {
         resolve: resolve as (result: unknown) => void,
@@ -143,6 +144,15 @@ export function createVSCodeTransport(api: VSCodeAPI): SessionService {
     getActivityLog: (timeRange?, projectSlug?) => request<import('../core/activity-index.js').ActivityIndexEntry[]>('getActivityLog', { ...timeRange, projectSlug }),
     getResponsePreview: (file, offset) => request<string | null>('getResponsePreview', { file, offset }),
     getLineageGraph: () => request<Array<{ sessionFile: string; parentFile: string | null }>>('getLineageGraph'),
+
+    transcribeAudio: (pcmFloat32, sampleRate) => {
+      const audioBase64 = float32ToBase64(pcmFloat32);
+      return request<{ text: string }>('transcribeAudio', { audioBase64, sampleRate });
+    },
+
+    startVoiceCapture: () => request<void>('startVoiceCapture'),
+    // Longer timeout: first call may download + load VAD/STT models
+    stopVoiceCapture: () => request<{ text: string }>('stopVoiceCapture', undefined, 120_000),
 
     onEvent(handler) {
       eventHandlers.push(handler);

--- a/src/webview/transport-websocket.ts
+++ b/src/webview/transport-websocket.ts
@@ -13,6 +13,7 @@ import type { TranscriptEntry } from '../core/transcript.js';
 import type { TurnReceipt } from '../core/agent-adapter.js';
 import type { WireProviderConfig, WireSettingsSnapshot, SettingsPatch } from '../core/settings/types.js';
 import type { VendorModelGroup } from './components/control-panel/types.js';
+import { float32ToBase64 } from './utils/encoding.js';
 
 /** Pending request awaiting a response. */
 interface PendingRequest {
@@ -182,6 +183,12 @@ export function createWebSocketTransport(url: string): SessionService {
     getActivityLog: (timeRange?, projectSlug?) => request<import('../core/activity-index.js').ActivityIndexEntry[]>('getActivityLog', { ...timeRange, projectSlug }),
     getResponsePreview: (file, offset) => request<string | null>('getResponsePreview', { file, offset }),
     getLineageGraph: () => request<Array<{ sessionFile: string; parentFile: string | null }>>('getLineageGraph'),
+
+    transcribeAudio: (pcmFloat32, sampleRate) => {
+      const audioBase64 = float32ToBase64(pcmFloat32);
+      console.log(`[Voice] transport: sending transcribeAudio RPC, ${pcmFloat32.length} samples, base64 length: ${audioBase64.length}`);
+      return request<{ text: string }>('transcribeAudio', { audioBase64, sampleRate });
+    },
 
     onEvent(handler) {
       eventHandlers.push(handler);

--- a/src/webview/transport.ts
+++ b/src/webview/transport.ts
@@ -84,6 +84,13 @@ export interface SessionService {
   getResponsePreview(file: string, offset: number): Promise<string | null>;
   getLineageGraph(): Promise<Array<{ sessionFile: string; parentFile: string | null }>>;
 
+  /** Voice input — send recorded audio to host for VAD + STT transcription */
+  transcribeAudio(pcmFloat32: Float32Array, sampleRate: number): Promise<{ text: string }>;
+
+  /** Host-side voice capture (VS Code only — bypasses webview getUserMedia restriction) */
+  startVoiceCapture?(): Promise<void>;
+  stopVoiceCapture?(): Promise<{ text: string }>;
+
   dispose(): void;
 
   /** Fire-and-forget message to the host. VS Code only; no-op elsewhere. */

--- a/src/webview/utils/encoding.ts
+++ b/src/webview/utils/encoding.ts
@@ -1,0 +1,24 @@
+/**
+ * Binary Encoding Utilities — Float32Array ↔ base64 for JSON transport
+ *
+ * Used by both WebSocket and VS Code transports to serialize audio data.
+ *
+ * @module utils/encoding
+ */
+
+/**
+ * Encode a Float32Array as a base64 string for JSON transport.
+ *
+ * Uses chunked String.fromCharCode to avoid O(n²) string concatenation
+ * that occurs with byte-by-byte appending.
+ */
+export function float32ToBase64(pcmFloat32: Float32Array): string {
+  const bytes = new Uint8Array(pcmFloat32.buffer, pcmFloat32.byteOffset, pcmFloat32.byteLength);
+  const chunks: string[] = [];
+  const CHUNK_SIZE = 8192;
+  for (let i = 0; i < bytes.length; i += CHUNK_SIZE) {
+    const chunk = bytes.subarray(i, Math.min(i + CHUNK_SIZE, bytes.length));
+    chunks.push(String.fromCharCode(...chunk));
+  }
+  return btoa(chunks.join(''));
+}


### PR DESCRIPTION
## Summary
- Platform-native audio capture (Swift/macOS, PowerShell/Windows, arecord-parecord-pw-record/Linux) with no external tool installs required
- Local Silero VAD + Moonshine Base STT via onnxruntime-node and @huggingface/transformers — models lazy-downloaded on first use
- Dual capture modes: browser-side getUserMedia for dev server, host-side RPC delegation for VS Code extension
- Push-to-talk UI with mic button in ChatInput

## Limitations
- Requires GLIBC ≥ 2.33 — snap-packaged VS Code (GLIBC 2.31) not supported for voice; use .deb install instead
- Voice capture is desktop-only (not supported in remote/SSH/Codespaces)

## Test plan
- [ ] Dev server: `npm run dev`, click mic button, speak, verify transcription appears in input
- [ ] VS Code (.deb): install extension, Cmd+Shift+Space or click mic, speak, verify transcription
- [ ] Verify first-run model download completes successfully
- [ ] Verify no crash when voice fails gracefully (e.g. no mic permission)

🤖 Generated with [Claude Code](https://claude.com/claude-code)