### PR TITLE
Release 0.3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@
 
 ---
 
+## What's New in v0.3.4
+
+A Windows hotfix for WSL workspace detection.
+
+### Bug fixes
+
+- **WSL workspace detection on the Tauri desktop app** — fixed an infinite re-provision loop on Windows that left WSL sessions invisible in the workspace picker. The version probe was reading from an orphaned `node_modules/crispy/` directory left behind by older installs (pre-rename), so every startup mistakenly re-provisioned WSL and sometimes lost a port-bind race with the dying daemon. Detection now resolves through the bin symlink (always reads the actually-installed package), the install path scrubs the legacy directory, and daemon shutdown polls for graceful exit before SIGKILL instead of racing a fixed sleep. Affects anyone who installed Crispy before the package was renamed to `crispy-code`.
+
 ## What's New in v0.3.3
 
 A live sessions panel, tabbed terminals, and orchestration polish.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crispy-code",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crispy-code",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Crispy",
   "icon": "media/crispy-icon.png",
   "description": "A GUI for Claude Code and Codex, built for multi-agent orchestration — with 'superthink' adversarial verification, agent memory, and Discord remote access.",
-  "version": "0.3.4-rc.1",
+  "version": "0.3.4",
   "publisher": "the-sylvester",
   "license": "MIT",
   "files": [

--- a/tauri/package.json
+++ b/tauri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crispy-desktop",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "description": "Crispy desktop app — native window shell for the Crispy daemon",
   "scripts": {

--- a/tauri/src-tauri/Cargo.toml
+++ b/tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crispy-desktop"
-version = "0.3.4-rc.1"
+version = "0.3.4"
 description = "Crispy desktop app"
 authors = ["Sylvester Wong"]
 edition = "2021"

--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -975,11 +975,15 @@ fn detect_wsl() -> Option<WslDetection> {
         .map(|o| o.status.success())
         .unwrap_or(false);
 
-    // Check installed version
+    // Check installed version. Resolve via the bin symlink so we read the
+    // package.json of whichever package npm last installed `crispy` from —
+    // avoids reading a stale `crispy/` directory left over from the
+    // pre-rename install (which would trigger a permanent version-mismatch
+    // re-provision loop, because npm install never removes orphaned packages).
     let installed_version = if crispy_installed {
         wsl_command()
             .args(["-d", &distro, "-e", "bash", "-c",
-                   "node -e \"try{process.stdout.write(require(process.env.HOME+'/.crispy/node_modules/crispy/package.json').version)}catch{process.stdout.write(require(process.env.HOME+'/.crispy/node_modules/crispy-code/package.json').version)}\" 2>/dev/null"])
+                   "node -p \"const fs=require('fs'),path=require('path');const tgt=fs.realpathSync(process.env.HOME+'/.crispy/node_modules/.bin/crispy');require(path.join(path.dirname(path.dirname(tgt)),'package.json')).version\" 2>/dev/null"])
             .output()
             .ok()
             .and_then(|o| {
@@ -1095,8 +1099,14 @@ async fn provision_wsl_crispy(app: &AppHandle, distro: &str) -> Result<(), Strin
     // Then npm install from the tarball to get correct Linux native modules.
     // npm pack on Windows strips Unix execute bits and may introduce CRLF line
     // endings.  After `npm install` we fix both so shebangs work in WSL.
+    //
+    // Strip the pre-rename `crispy/` install before npm runs: npm doesn't
+    // prune orphaned deps on install, so a stale `crispy/` (from the rename
+    // to `crispy-code`) lingers forever otherwise.
     let install_cmd = format!(
-        r#"src=$(wslpath -a -u '{}'); npm install --prefix "$HOME/.crispy" "$src" 2>&1 && \
+        r#"rm -rf "$HOME/.crispy/node_modules/crispy"; \
+[ -f "$HOME/.crispy/package.json" ] && node -e "try{{const fs=require('fs'),p=process.env.HOME+'/.crispy/package.json',j=JSON.parse(fs.readFileSync(p));if(j.dependencies&&j.dependencies.crispy){{delete j.dependencies.crispy;fs.writeFileSync(p,JSON.stringify(j,null,2)+'\n')}}}}catch(e){{}}" 2>/dev/null; \
+src=$(wslpath -a -u '{}'); npm install --prefix "$HOME/.crispy" "$src" 2>&1 && \
 for f in "$HOME/.crispy/node_modules/crispy-code/dist/crispy-dispatch.js" \
          "$HOME/.crispy/node_modules/crispy-code/dist/crispy-cli.js" \
          "$HOME/.crispy/node_modules/crispy-code/dist/recall.js" \
@@ -1197,12 +1207,26 @@ fn start_wsl_daemon_manager(app_handle: AppHandle) {
 
         if detection.daemon_port.is_some() {
             log::info!("Killing existing WSL daemon to ensure fresh runtime");
+            // SIGTERM, then poll up to 5s for graceful exit, then SIGKILL
+            // if stubborn. Without this, the new daemon often loses a
+            // bind-port race against the dying old one and exits with
+            // "Another Crispy daemon is already running on port N".
             let _ = wsl_command()
                 .args(["-d", &detection.distro, "-e", "bash", "-c",
-                       "kill $(cat ~/.crispy/run/crispy.pid 2>/dev/null) 2>/dev/null; rm -f ~/.crispy/run/crispy.pid ~/.crispy/run/crispy.port"])
+                       r#"pid=$(cat ~/.crispy/run/crispy.pid 2>/dev/null)
+if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+  kill "$pid" 2>/dev/null
+  for i in $(seq 1 25); do
+    sleep 0.2
+    kill -0 "$pid" 2>/dev/null || break
+  done
+  if kill -0 "$pid" 2>/dev/null; then
+    kill -9 "$pid" 2>/dev/null
+    sleep 0.5
+  fi
+fi
+rm -f ~/.crispy/run/crispy.pid ~/.crispy/run/crispy.port"#])
                 .status();
-            // Brief pause for process cleanup
-            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
         }
 
         let port = {

--- a/tauri/src-tauri/tauri.conf.json
+++ b/tauri/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Crispy",
-  "version": "0.3.4-rc.1",
+  "version": "0.3.4",
   "identifier": "io.github.thesylvester.crispy",
   "build": {
     "frontendDist": "../src-frontend/"


### PR DESCRIPTION
## Summary

Hotfix release for the Tauri desktop app on Windows.

Users with a pre-rename `node_modules/crispy/` directory in WSL (anyone who installed Crispy before the package was renamed to `crispy-code` on Apr 8) were stuck in an infinite re-provision loop. The version probe read `0.3.0-rc.16` from the orphan dir, triggering re-provisioning on every startup, and the kill→spawn race produced "Another Crispy daemon is already running on port 3466" errors that left WSL workspaces invisible in the picker.

## Changes

- **`detect_wsl()`** — version probe resolves through `node_modules/.bin/crispy` symlink so it always reads the actually-installed package.json, not a stale orphan.
- **`provision_wsl_crispy()`** — `rm -rf` the legacy `crispy/` directory and strip its entry from `~/.crispy/package.json` before npm install. Self-healing on affected users' next startup.
- **`start_wsl_daemon_manager()`** — SIGTERM → poll up to 5s for graceful exit → SIGKILL if stubborn, replacing the fixed 500ms sleep that was racing port bind.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test:unit` passes (1148/1150, 2 expected skips)
- [x] `npm pack --dry-run` clean (4.5MB, no secrets, THIRD-PARTY-LICENSES included)
- [ ] CI: 6 VSIX platforms + Tauri Windows build